### PR TITLE
Minor fixes

### DIFF
--- a/guessit/__init__.py
+++ b/guessit/__init__.py
@@ -20,7 +20,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import pkg_resources
 from .__version__ import __version__
 
 __all__ = ['Guess', 'Language',

--- a/guessit/__main__.py
+++ b/guessit/__main__.py
@@ -213,6 +213,9 @@ def main(args=None, setup_logging=True):
         # Wrap sys.stdout into a StreamWriter to allow writing unicode.
         sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
 
+    # Needed for guessit.plugins.transformers.reload() to be called.
+    from guessit.plugins import transformers
+
     if args:
         options = get_opts().parse_args(args)
     else:  # pragma: no cover

--- a/guessit/__main__.py
+++ b/guessit/__main__.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 import logging
 import os
 
-from guessit import PY2, u, guess_file_info, __version__
+from guessit import PY2, u, guess_file_info
 from guessit.options import get_opts
 from guessit.__version__ import __version__
 
@@ -212,8 +212,6 @@ def main(args=None, setup_logging=True):
         # and http://stackoverflow.com/questions/4545661/unicodedecodeerror-when-redirecting-to-file
         # Wrap sys.stdout into a StreamWriter to allow writing unicode.
         sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
-
-    from guessit.plugins import transformers
 
     if args:
         options = get_opts().parse_args(args)

--- a/guessit/containers.py
+++ b/guessit/containers.py
@@ -21,10 +21,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import types
+
 from .patterns import compile_pattern, sep
 from . import base_text_type
 from .guess import Guess
-import types
 
 
 def _get_span(prop, match):

--- a/guessit/containers.py
+++ b/guessit/containers.py
@@ -41,8 +41,6 @@ def _get_span(prop, match):
         return start, end
     else:
         return match.span()
-        start = span[0]
-        end = span[1]
 
 
 def _trim_span(span, value, blanks = sep):

--- a/guessit/containers.py
+++ b/guessit/containers.py
@@ -82,14 +82,16 @@ def _get_groups(compiled_re):
 
 
 class NoValidator(object):
-    def validate(self, prop, string, node, match, entry_start, entry_end):
+    @staticmethod
+    def validate(prop, string, node, match, entry_start, entry_end):
         return True
 
 
 class LeftValidator(object):
     """Make sure our match is starting by separator, or by another entry"""
 
-    def validate(self, prop, string, node, match, entry_start, entry_end):
+    @staticmethod
+    def validate(prop, string, node, match, entry_start, entry_end):
         span = _get_span(prop, match)
         span = _trim_span(span, string[span[0]:span[1]])
         start, end = span
@@ -104,7 +106,8 @@ class LeftValidator(object):
 class RightValidator(object):
     """Make sure our match is ended by separator, or by another entry"""
 
-    def validate(self, prop, string, node, match, entry_start, entry_end):
+    @staticmethod
+    def validate(prop, string, node, match, entry_start, entry_end):
         span = _get_span(prop, match)
         span = _trim_span(span, string[span[0]:span[1]])
         start, end = span
@@ -280,7 +283,8 @@ class LeavesValidator(DefaultValidator):
                         return ret
             return False
 
-    def _check_rule(self, lambda_, previous_leaf):
+    @staticmethod
+    def _check_rule(lambda_, previous_leaf):
         return lambda_(previous_leaf)
 
 
@@ -621,7 +625,8 @@ class PropertiesContainer(object):
                     return guess
         return guesses
 
-    def _effective_prop_value(self, prop, group_name, input=None, span=None, sep_replacement=None):
+    @staticmethod
+    def _effective_prop_value(prop, group_name, input=None, span=None, sep_replacement=None):
         if prop.canonical_form:
             return prop.canonical_form
         if input is None:

--- a/guessit/date.py
+++ b/guessit/date.py
@@ -67,9 +67,9 @@ def search_year(string):
     if match:
         year = int(match.group(1))
         if valid_year(year):
-            return (year, match.span(1))
+            return year, match.span(1)
 
-    return (None, None)
+    return None, None
 
 
 def search_date(string, year_first=None, day_first=True):

--- a/guessit/date.py
+++ b/guessit/date.py
@@ -21,7 +21,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
-
 import re
 
 from dateutil import parser

--- a/guessit/fileutils.py
+++ b/guessit/fileutils.py
@@ -20,10 +20,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from guessit import s, u
 import os.path
 import zipfile
 import io
+
+from guessit import s, u
 
 
 def split_path(path):

--- a/guessit/guess.py
+++ b/guessit/guess.py
@@ -282,13 +282,13 @@ def choose_int(g1, g2):
     properties when they are integers."""
     v1, c1 = g1  # value, confidence
     v2, c2 = g2
-    if (v1 == v2):
-        return (v1, 1 - (1 - c1) * (1 - c2))
+    if v1 == v2:
+        return v1, 1 - (1 - c1) * (1 - c2)
     else:
         if c1 > c2:
-            return (v1, c1 - c2)
+            return v1, c1 - c2
         else:
-            return (v2, c2 - c1)
+            return v2, c2 - c1
 
 
 def choose_string(g1, g2):

--- a/guessit/guess.py
+++ b/guessit/guess.py
@@ -20,12 +20,14 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from guessit import UnicodeMixin, s, u, base_text_type
-from babelfish import Language, Country
-from guessit.textutils import common_words
 import json
 import datetime
 import logging
+
+from guessit import UnicodeMixin, s, u, base_text_type
+from babelfish import Language, Country
+from guessit.textutils import common_words
+
 
 log = logging.getLogger(__name__)
 

--- a/guessit/hash_ed2k.py
+++ b/guessit/hash_ed2k.py
@@ -20,11 +20,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from guessit import s, to_hex
 import hashlib
 import os.path
-
 from functools import reduce
+
+from guessit import s, to_hex
 
 
 def hash_file(filename):

--- a/guessit/language.py
+++ b/guessit/language.py
@@ -82,7 +82,7 @@ class GuessitConverter(babelfish.LanguageReverseConverter):
         if with_country:
             lang = Language.fromguessit(with_country.group(1).strip())
             lang.country = babelfish.Country.fromguessit(with_country.group(2).strip())
-            return (lang.alpha3, lang.country.alpha2 if lang.country else None, lang.script or None)
+            return lang.alpha3, lang.country.alpha2 if lang.country else None, lang.script or None
 
         # exceptions come first, as they need to override a potential match
         # with any of the other guessers

--- a/guessit/language.py
+++ b/guessit/language.py
@@ -20,13 +20,16 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from guessit import UnicodeMixin, base_text_type, u
-from guessit.textutils import find_words
-from babelfish import Language, Country
-import babelfish
 import re
 import logging
+
+from guessit import u
+from guessit.textutils import find_words
+
+from babelfish import Language, Country
+import babelfish
 from guessit.guess import Guess
+
 
 __all__ = ['Language', 'UNDETERMINED',
            'search_language', 'guess_language']

--- a/guessit/language.py
+++ b/guessit/language.py
@@ -74,7 +74,8 @@ class GuessitConverter(babelfish.LanguageReverseConverter):
                 babelfish.country_converters['name'].codes |
                 frozenset(self.guessit_exceptions.keys()))
 
-    def convert(self, alpha3, country=None, script=None):
+    @staticmethod
+    def convert(alpha3, country=None, script=None):
         return str(babelfish.Language(alpha3, country, script))
 
     def reverse(self, name):
@@ -133,7 +134,8 @@ class GuessitCountryConverter(babelfish.CountryReverseConverter):
                 frozenset(babelfish.COUNTRIES.values()) |
                 frozenset(self.guessit_exceptions.keys()))
 
-    def convert(self, alpha2):
+    @staticmethod
+    def convert(alpha2):
         if alpha2 == 'GB':
             return 'UK'
         return str(Country(alpha2))

--- a/guessit/matcher.py
+++ b/guessit/matcher.py
@@ -149,7 +149,8 @@ class IterativeMatcher(object):
 
         return second_pass_options
 
-    def _validate_options(self, options):
+    @staticmethod
+    def _validate_options(options):
         valid_filetypes = ('subtitle', 'info', 'video',
                            'movie', 'moviesubtitle', 'movieinfo',
                            'episode', 'episodesubtitle', 'episodeinfo')

--- a/guessit/matcher.py
+++ b/guessit/matcher.py
@@ -23,13 +23,13 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 import logging
+import inspect
 
 from guessit import PY3, u
 from guessit.transfo import TransformerException
 from guessit.matchtree import MatchTree
 from guessit.textutils import normalize_unicode, clean_default
 from guessit.guess import Guess
-import inspect
 
 log = logging.getLogger(__name__)
 

--- a/guessit/matchtree.py
+++ b/guessit/matchtree.py
@@ -255,7 +255,7 @@ class BaseMatchTree(UnicodeMixin):
     def _other_leaf(self, leaf, offset):
         leaves = list(self.leaves())
         index = leaves.index(leaf) + offset
-        if index > 0 and index < len(leaves):
+        if 0 < index < len(leaves):
             return leaves[index]
         return None
 
@@ -263,7 +263,7 @@ class BaseMatchTree(UnicodeMixin):
         """Return previous leaves for this node"""
         leaves = list(self.leaves())
         index = leaves.index(leaf)
-        if index > 0 and index < len(leaves):
+        if 0 < index < len(leaves):
             previous_leaves = leaves[:index]
             previous_leaves.reverse()
             return previous_leaves
@@ -273,7 +273,7 @@ class BaseMatchTree(UnicodeMixin):
         """Return next leaves for this node"""
         leaves = list(self.leaves())
         index = leaves.index(leaf)
-        if index > 0 and index < len(leaves):
+        if 0 < index < len(leaves):
             return leaves[index + 1:len(leaves)]
         return []
 

--- a/guessit/matchtree.py
+++ b/guessit/matchtree.py
@@ -20,15 +20,16 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import copy
+import logging
+
 import guessit  # @UnusedImport needed for doctests
 from guessit import UnicodeMixin, base_text_type
 from guessit.textutils import clean_default, str_fill
 from guessit.patterns import group_delimiters
-from guessit.guess import (merge_similar_guesses, smart_merge,
-                           choose_int, choose_string, Guess)
-from itertools import takewhile
-import copy
-import logging
+from guessit.guess import (smart_merge,
+                           Guess)
+
 
 log = logging.getLogger(__name__)
 

--- a/guessit/patterns/__init__.py
+++ b/guessit/patterns/__init__.py
@@ -23,8 +23,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import re
 
-from guessit import base_text_type
-
 group_delimiters = ['()', '[]', '{}']
 
 # separator character regexp

--- a/guessit/plugins/transformers.py
+++ b/guessit/plugins/transformers.py
@@ -19,13 +19,13 @@
 #
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-from guessit.options import reload as reload_options
+from logging import getLogger
 
-from stevedore import ExtensionManager
 from pkg_resources import EntryPoint
 
+from guessit.options import reload as reload_options
+from stevedore import ExtensionManager
 from stevedore.extension import Extension
-from logging import getLogger
 
 log = getLogger(__name__)
 

--- a/guessit/plugins/transformers.py
+++ b/guessit/plugins/transformers.py
@@ -73,7 +73,8 @@ class CustomTransformerExtensionManager(ExtensionManager):
                                                                 on_load_failure_callback=on_load_failure_callback,
                                                                 verify_requirements=verify_requirements)
 
-    def order_extensions(self, extensions):
+    @staticmethod
+    def order_extensions(extensions):
         """Order the loaded transformers
 
         It should follow those rules
@@ -85,7 +86,8 @@ class CustomTransformerExtensionManager(ExtensionManager):
         extensions.sort(key=lambda ext: -ext.obj.priority)
         return extensions
 
-    def _load_one_plugin(self, ep, invoke_on_load, invoke_args, invoke_kwds, verify_requirements=True):
+    @staticmethod
+    def _load_one_plugin(ep, invoke_on_load, invoke_args, invoke_kwds, verify_requirements=True):
         if not ep.dist:
             # `require` argument of ep.load() is deprecated in newer versions of setuptools
             if hasattr(ep, 'resolve'):
@@ -108,7 +110,8 @@ class CustomTransformerExtensionManager(ExtensionManager):
     def objects(self):
         return self.map(self._get_obj)
 
-    def _get_obj(self, ext):
+    @staticmethod
+    def _get_obj(ext):
         return ext.obj
 
     def object(self, name):

--- a/guessit/test/__init__.py
+++ b/guessit/test/__init__.py
@@ -21,6 +21,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+
 from guessit.slogging import setup_logging
+
 setup_logging()
 logging.disable(logging.INFO)

--- a/guessit/test/guessittest.py
+++ b/guessit/test/guessittest.py
@@ -20,13 +20,16 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from guessit import base_text_type, u
 from collections import defaultdict
-from unittest import TestCase, TestLoader, TextTestRunner
+from unittest import TestCase, TestLoader
 import shlex
-import babelfish
-import yaml, logging, sys, os
+import logging
+import os
+import sys
 from os.path import *
+
+import babelfish
+import yaml
 
 
 def currentPath():
@@ -42,12 +45,12 @@ def addImportPath(path):
 
 log = logging.getLogger(__name__)
 
-from guessit.plugins import transformers
 from guessit.options import get_opts
-import guessit
+from guessit import base_text_type
 from guessit import *
 from guessit.matcher import *
 from guessit.fileutils import *
+import guessit
 
 
 def allTests(testClass):

--- a/guessit/test/guessittest.py
+++ b/guessit/test/guessittest.py
@@ -30,13 +30,13 @@ from os.path import *
 
 
 def currentPath():
-    '''Returns the path in which the calling file is located.'''
+    """Returns the path in which the calling file is located."""
     return dirname(join(os.getcwd(), sys._getframe(1).f_globals['__file__']))
 
 
 def addImportPath(path):
-    '''Function that adds the specified path to the import path. The path can be
-    absolute or relative to the calling file.'''
+    """Function that adds the specified path to the import path. The path can be
+    absolute or relative to the calling file."""
     importPath = abspath(join(currentPath(), path))
     sys.path = [importPath] + sys.path
 
@@ -94,7 +94,7 @@ class TestGuessit(TestCase):
                 log.exception("An exception has occured in %s: %s" % (filename, e))
                 continue
 
-            total = total + 1
+            total += 1
 
             # no need for these in the unittests
             if remove_type:

--- a/guessit/test/test_language.py
+++ b/guessit/test/test_language.py
@@ -22,8 +22,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from guessit.test.guessittest import *
 
-import io
-
 
 class TestLanguage(TestGuessit):
 

--- a/guessit/test/test_main.py
+++ b/guessit/test/test_main.py
@@ -21,8 +21,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from guessit.test.guessittest import *
-from guessit.fileutils import split_path, file_in_same_dir
-from guessit.textutils import strip_brackets, str_replace, str_fill
+from guessit.fileutils import file_in_same_dir
 from guessit import PY2
 from guessit import __main__
 

--- a/guessit/test/test_utils.py
+++ b/guessit/test/test_utils.py
@@ -131,18 +131,18 @@ class TestUtils(TestGuessit):
 
         assert search_date(' This happened on 13-04-%s. ' % (today_year_2,)) == (date(today.year, 4, 13), (18, 26))
         assert search_date(' This happened on 22-04-%s. ' % (future_year_2,)) == (date(future.year, 4, 22), (18, 26))
-        assert search_date(' This happened on 20-04-%s. ' % (past_year_2)) == (date(past.year, 4, 20), (18, 26))
+        assert search_date(' This happened on 20-04-%s. ' % past_year_2) == (date(past.year, 4, 20), (18, 26))
 
         assert search_date(' This happened on 13-06-14. ', year_first=True) == (date(2013, 6, 14), (18, 26))
         assert search_date(' This happened on 13-05-14. ', year_first=False) == (date(2014, 5, 13), (18, 26))
 
         assert search_date(' This happened on 04-13-%s. ' % (today_year_2,)) == (date(today.year, 4, 13), (18, 26))
         assert search_date(' This happened on 04-22-%s. ' % (future_year_2,)) == (date(future.year, 4, 22), (18, 26))
-        assert search_date(' This happened on 04-20-%s. ' % (past_year_2)) == (date(past.year, 4, 20), (18, 26))
+        assert search_date(' This happened on 04-20-%s. ' % past_year_2) == (date(past.year, 4, 20), (18, 26))
 
         assert search_date(' This happened on 35-12-%s. ' % (today_year_2,)) == (None, None)
         assert search_date(' This happened on 37-18-%s. ' % (future_year_2,)) == (None, None)
-        assert search_date(' This happened on 44-42-%s. ' % (past_year_2)) == (None, None)
+        assert search_date(' This happened on 44-42-%s. ' % past_year_2) == (None, None)
 
         assert search_date(' This happened on %s. ' % (today, )) == (today, (18, 28))
         assert search_date(' This happened on %s. ' % (future, )) == (future, (18, 28))

--- a/guessit/test/test_utils.py
+++ b/guessit/test/test_utils.py
@@ -20,13 +20,15 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from datetime import date, timedelta
+
 from guessit.test.guessittest import *
+
 from guessit.fileutils import split_path
 from guessit.textutils import strip_brackets, str_replace, str_fill, from_camel, is_camel,\
     levenshtein, reorder_title
 from guessit import PY2
 from guessit.date import search_date, search_year
-from datetime import datetime, date, timedelta
 
 
 class TestUtils(TestGuessit):

--- a/guessit/textutils.py
+++ b/guessit/textutils.py
@@ -247,8 +247,8 @@ def find_first_level_groups(string, enclosing, blank_sep=None):
     return split_on_groups(string, groups)
 
 
-_camel_word2_set = set(('is', 'to',))
-_camel_word3_set = set(('the',))
+_camel_word2_set = {'is', 'to'}
+_camel_word3_set = {'the'}
 
 
 def _camel_split_and_lower(string, i):
@@ -304,7 +304,7 @@ def _camel_split_and_lower(string, i):
 
         need_lower = not uppercase_word and not mixedcase_word and need_split
 
-        return (need_split, need_lower)
+        return need_split, need_lower
 
 
 def is_camel(string):

--- a/guessit/transfo/expected_series.py
+++ b/guessit/transfo/expected_series.py
@@ -19,12 +19,11 @@
 #
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+import re
+
 from guessit.containers import PropertiesContainer
 from guessit.matcher import GuessFinder
-
 from guessit.plugins.transformers import Transformer
-
-import re
 
 
 class ExpectedSeries(Transformer):

--- a/guessit/transfo/expected_series.py
+++ b/guessit/transfo/expected_series.py
@@ -37,7 +37,8 @@ class ExpectedSeries(Transformer):
     def should_process(self, mtree, options=None):
         return options and options.get('expected_series')
 
-    def expected_series(self, string, node=None, options=None):
+    @staticmethod
+    def expected_series(string, node=None, options=None):
         container = PropertiesContainer(enhance=True, canonical_from_pattern=False)
 
         for expected_serie in options.get('expected_series'):

--- a/guessit/transfo/expected_title.py
+++ b/guessit/transfo/expected_title.py
@@ -38,7 +38,8 @@ class ExpectedTitle(Transformer):
     def should_process(self, mtree, options=None):
         return options and options.get('expected_title')
 
-    def expected_titles(self, string, node=None, options=None):
+    @staticmethod
+    def expected_titles(string, node=None, options=None):
         container = PropertiesContainer(enhance=True, canonical_from_pattern=False)
 
         for expected_title in options.get('expected_title'):

--- a/guessit/transfo/expected_title.py
+++ b/guessit/transfo/expected_title.py
@@ -20,12 +20,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
+
 from guessit.containers import PropertiesContainer
 from guessit.matcher import GuessFinder
-
 from guessit.plugins.transformers import Transformer
-
-import re
 
 
 class ExpectedTitle(Transformer):

--- a/guessit/transfo/guess_country.py
+++ b/guessit/transfo/guess_country.py
@@ -50,7 +50,8 @@ class GuessCountry(Transformer):
         options = options or {}
         return options.get('country', True)
 
-    def _scan_country(self, country, strict=False):
+    @staticmethod
+    def _scan_country(country, strict=False):
         """
         Find a country if it is at the start or end of country string
         """
@@ -81,7 +82,8 @@ class GuessCountry(Transformer):
 
         return Country.fromguessit(country), (start, end)
 
-    def is_valid_country(self, country, options=None):
+    @staticmethod
+    def is_valid_country(country, options=None):
         if options and options.get('allowed_countries'):
             allowed_countries = options.get('allowed_countries')
             return country.name.lower() in allowed_countries or country.alpha2.lower() in allowed_countries

--- a/guessit/transfo/guess_country.py
+++ b/guessit/transfo/guess_country.py
@@ -20,6 +20,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
+
 from guessit.plugins.transformers import Transformer
 from babelfish import Country
 from guessit import Guess
@@ -27,7 +29,7 @@ from guessit.textutils import iter_words
 from guessit.matcher import GuessFinder, found_guess
 from guessit.language import LNG_COMMON_WORDS
 import babelfish
-import logging
+
 
 log = logging.getLogger(__name__)
 

--- a/guessit/transfo/guess_date.py
+++ b/guessit/transfo/guess_date.py
@@ -38,7 +38,8 @@ class GuessDate(Transformer):
     def supported_properties(self):
         return ['date']
 
-    def guess_date(self, string, node=None, options=None):
+    @staticmethod
+    def guess_date(string, node=None, options=None):
         date, span = search_date(string, options.get('date_year_first') if options else False, options.get('date_day_first') if options else False)
         if date:
             return {'date': date}, span

--- a/guessit/transfo/guess_episode_details.py
+++ b/guessit/transfo/guess_episode_details.py
@@ -20,10 +20,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import itertools
+
 from guessit.plugins.transformers import Transformer
 from guessit.matcher import found_guess
 from guessit.containers import PropertiesContainer
-import itertools
 
 
 class GuessEpisodeDetails(Transformer):

--- a/guessit/transfo/guess_episode_info_from_position.py
+++ b/guessit/transfo/guess_episode_info_from_position.py
@@ -110,7 +110,8 @@ class GuessEpisodeInfoFromPosition(Transformer):
         options = options or {}
         return not options.get('skip_title') and mtree.guess.get('type', '').startswith('episode')
 
-    def _filter_candidates(self, candidates, options):
+    @staticmethod
+    def _filter_candidates(candidates, options):
         episode_details_transformer = get_transformer('guess_episode_details')
         if episode_details_transformer:
             return [n for n in candidates if not episode_details_transformer.container.find_properties(n.value, n, options, re_match=True)]

--- a/guessit/transfo/guess_episodes_rexps.py
+++ b/guessit/transfo/guess_episodes_rexps.py
@@ -136,7 +136,8 @@ class GuessEpisodesRexps(Transformer):
             return list_parser(value, 'seasonList')
 
         class ResolutionCollisionValidator(object):
-            def validate(self, prop, string, node, match, entry_start, entry_end):
+            @staticmethod
+            def validate(prop, string, node, match, entry_start, entry_end):
                 return len(match.group(2)) < 3 # limit
 
         self.container.register_property(None, r'(' + season_words_re.pattern + sep + '?(?P<season>' + numeral + ')' + sep + '?' + season_words_re.pattern + '?)', confidence=1.0, formatter=parse_numeral)

--- a/guessit/transfo/guess_episodes_rexps.py
+++ b/guessit/transfo/guess_episodes_rexps.py
@@ -20,13 +20,14 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
+
 from guessit.plugins.transformers import Transformer
 from guessit.matcher import GuessFinder
 from guessit.patterns import sep, build_or_pattern
 from guessit.containers import PropertiesContainer, WeakValidator, NoValidator, ChainedValidator, DefaultValidator, \
     FormatterValidator
 from guessit.patterns.numeral import numeral, digital_numeral, parse_numeral
-import re
 
 
 class GuessEpisodesRexps(Transformer):

--- a/guessit/transfo/guess_episodes_rexps.py
+++ b/guessit/transfo/guess_episodes_rexps.py
@@ -76,7 +76,7 @@ class GuessEpisodesRexps(Transformer):
                 else:
                     match = range_separators_re.search(discrete_elements[i])
                     if match and match.start() == 0:
-                        proper_discrete_elements[i-1] = proper_discrete_elements[i-1] + discrete_elements[i]
+                        proper_discrete_elements[i - 1] += discrete_elements[i]
                     elif match and match.end() == len(discrete_elements[i]):
                         proper_discrete_elements.append(discrete_elements[i] + discrete_elements[i + 1])
                     else:

--- a/guessit/transfo/guess_filetype.py
+++ b/guessit/transfo/guess_filetype.py
@@ -28,7 +28,7 @@ from guessit.guess import Guess
 from guessit.patterns.extension import subtitle_exts, info_exts, video_exts
 from guessit.transfo import TransformerException
 from guessit.plugins.transformers import Transformer, get_transformer
-from guessit.matcher import log_found_guess, found_guess, found_property
+from guessit.matcher import log_found_guess, found_guess
 
 
 class GuessFiletype(Transformer):

--- a/guessit/transfo/guess_filetype.py
+++ b/guessit/transfo/guess_filetype.py
@@ -135,7 +135,7 @@ class GuessFiletype(Transformer):
         # if we have an episode_rexp (eg: s02e13), it is an episode
         episode_transformer = get_transformer('guess_episodes_rexps')
         if episode_transformer:
-            filename_parts = list(x.value for x in mtree.unidentified_leaves());
+            filename_parts = list(x.value for x in mtree.unidentified_leaves())
             filename_parts.append(filename)
             for filename_part in filename_parts:
                 guess = episode_transformer.guess_episodes_rexps(filename_part)

--- a/guessit/transfo/guess_idnumber.py
+++ b/guessit/transfo/guess_idnumber.py
@@ -43,8 +43,8 @@ class GuessIdnumber(Transformer):
         if match is not None:
             result = match.groupdict()
             switch_count = 0
-            switch_letter_count = 0;
-            letter_count = 0;
+            switch_letter_count = 0
+            letter_count = 0
             last_letter = None
 
             last = _LETTER

--- a/guessit/transfo/guess_idnumber.py
+++ b/guessit/transfo/guess_idnumber.py
@@ -20,9 +20,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
+
 from guessit.plugins.transformers import Transformer
 from guessit.matcher import GuessFinder
-import re
+
 
 _DIGIT = 0
 _LETTER = 1

--- a/guessit/transfo/guess_language.py
+++ b/guessit/transfo/guess_language.py
@@ -38,14 +38,16 @@ class GuessLanguage(Transformer):
     def supported_properties(self):
         return ['language', 'subtitleLanguage']
 
-    def guess_language(self, string, node=None, options=None):
+    @staticmethod
+    def guess_language(string, node=None, options=None):
         allowed_languages = None
         if options and 'allowed_languages' in options:
             allowed_languages = options.get('allowed_languages')
         guess = search_language(string, allowed_languages)
         return guess
 
-    def _skip_language_on_second_pass(self, mtree, node):
+    @staticmethod
+    def _skip_language_on_second_pass(mtree, node):
         """Check if found node is a valid language node, or if it's a false positive.
 
         :param mtree: Tree detected on first pass.
@@ -138,7 +140,8 @@ class GuessLanguage(Transformer):
     def process(self, mtree, options=None):
         GuessFinder(self.guess_language, None, self.log, options).process_nodes(mtree.unidentified_leaves())
 
-    def promote_subtitle(self, node):
+    @staticmethod
+    def promote_subtitle(node):
         if 'language' in node.guess:
             node.guess.set('subtitleLanguage', node.guess['language'],
                            confidence=node.guess.confidence('language'))

--- a/guessit/transfo/guess_properties.py
+++ b/guessit/transfo/guess_properties.py
@@ -114,7 +114,8 @@ class GuessProperties(Transformer):
 
         class ResolutionValidator(object):
             """Make sure our match is surrounded by separators, or by another entry"""
-            def validate(self, prop, string, node, match, entry_start, entry_end):
+            @staticmethod
+            def validate(prop, string, node, match, entry_start, entry_end):
                 """
                 span = _get_span(prop, match)
                 span = _trim_span(span, string[span[0]:span[1]])

--- a/guessit/transfo/guess_properties.py
+++ b/guessit/transfo/guess_properties.py
@@ -20,14 +20,14 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from guessit.containers import PropertiesContainer, WeakValidator, LeavesValidator, QualitiesContainer, NoValidator, \
-    ChainedValidator, DefaultValidator, OnlyOneValidator, LeftValidator, NeighborValidator
+import re
+
+from guessit.containers import PropertiesContainer, WeakValidator, LeavesValidator, QualitiesContainer, ChainedValidator, DefaultValidator, OnlyOneValidator, LeftValidator, NeighborValidator
 from guessit.patterns import sep, build_or_pattern
 from guessit.patterns.extension import subtitle_exts, video_exts, info_exts
 from guessit.patterns.numeral import numeral, parse_numeral
 from guessit.plugins.transformers import Transformer
 from guessit.matcher import GuessFinder, found_property
-import re
 
 
 class GuessProperties(Transformer):

--- a/guessit/transfo/guess_release_group.py
+++ b/guessit/transfo/guess_release_group.py
@@ -58,7 +58,8 @@ class GuessReleaseGroup(Transformer):
     def supported_properties(self):
         return self.container.get_supported_properties()
 
-    def _is_number(self, s):
+    @staticmethod
+    def _is_number(s):
         try:
             int(s)
             return True
@@ -102,7 +103,8 @@ class GuessReleaseGroup(Transformer):
                 return True
         return False
 
-    def is_leaf_previous(self, leaf, node):
+    @staticmethod
+    def is_leaf_previous(leaf, node):
         if leaf.span[1] <= node.span[0]:
             for idx in range(leaf.span[1], node.span[0]):
                 if leaf.root.value[idx] not in sep:
@@ -110,7 +112,8 @@ class GuessReleaseGroup(Transformer):
             return True
         return False
 
-    def validate_next_leaves(self, node):
+    @staticmethod
+    def validate_next_leaves(node):
         if 'series' in node.root.info or 'title' in node.root.info:
             # --expected-series or --expected-title is used.
             return True

--- a/guessit/transfo/guess_release_group.py
+++ b/guessit/transfo/guess_release_group.py
@@ -20,13 +20,14 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
+
 from guessit.plugins.transformers import Transformer
 from guessit.matcher import GuessFinder, build_guess
 from guessit.containers import PropertiesContainer
 from guessit.patterns import sep
 from guessit.guess import Guess
 from guessit.textutils import strip_brackets
-import re
 
 
 class GuessReleaseGroup(Transformer):

--- a/guessit/transfo/guess_weak_episodes_rexps.py
+++ b/guessit/transfo/guess_weak_episodes_rexps.py
@@ -20,14 +20,15 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
+
 from guessit.plugins.transformers import Transformer
+
 from guessit.matcher import GuessFinder
 from guessit.patterns import sep, build_or_pattern
-from guessit.containers import PropertiesContainer, LeavesValidator, NoValidator, WeakValidator
+from guessit.containers import PropertiesContainer
 from guessit.patterns.numeral import numeral, parse_numeral
 from guessit.date import valid_year
-
-import re
 
 
 class GuessWeakEpisodesRexps(Transformer):

--- a/guessit/transfo/guess_website.py
+++ b/guessit/transfo/guess_website.py
@@ -19,11 +19,14 @@
 #
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pkg_resources import resource_stream  # @UnresolvedImport
+
 from guessit.patterns import build_or_pattern
 from guessit.containers import PropertiesContainer
 from guessit.plugins.transformers import Transformer
 from guessit.matcher import GuessFinder
-from pkg_resources import resource_stream  # @UnresolvedImport
+
 
 TLDS = [l.strip().decode('utf-8')
         for l in resource_stream('guessit', 'tlds-alpha-by-domain.txt').readlines()

--- a/guessit/transfo/guess_year.py
+++ b/guessit/transfo/guess_year.py
@@ -32,7 +32,8 @@ class GuessYear(Transformer):
     def supported_properties(self):
         return ['year']
 
-    def guess_year(self, string, node=None, options=None):
+    @staticmethod
+    def guess_year(string, node=None, options=None):
         year, span = search_year(string)
         if year:
             return {'year': year}, span

--- a/guessit/transfo/split_explicit_groups.py
+++ b/guessit/transfo/split_explicit_groups.py
@@ -20,10 +20,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from functools import reduce
+
 from guessit.plugins.transformers import Transformer
 from guessit.textutils import find_first_level_groups
 from guessit.patterns import group_delimiters
-from functools import reduce
 
 
 class SplitExplicitGroups(Transformer):

--- a/guessit/transfo/split_on_dash.py
+++ b/guessit/transfo/split_on_dash.py
@@ -20,9 +20,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
+
 from guessit.plugins.transformers import Transformer
 from guessit.patterns import sep
-import re
 
 
 class SplitOnDash(Transformer):

--- a/guessit/transfo/split_path_components.py
+++ b/guessit/transfo/split_path_components.py
@@ -20,9 +20,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from os.path import splitext
+
 from guessit.plugins.transformers import Transformer
 from guessit import fileutils
-from os.path import splitext
 
 
 class SplitPathComponents(Transformer):


### PR DESCRIPTION
These are mostly PyCharm autofixes. I have tried not to change anything related to the coding style (PEP8) because I wasn't sure we're using one.

The specific fixes that I used were:
1. Removing redundant braces.
2. Improving assignments and inequation conditions.
3. Removing set function where unnecessary.
4. Using triple double-quotes for docstrings.
5. Removing trailing semi-colons.
6. Removing unreachable code.
7. Optimizing imports.
8. Making static methods static.

One big issue that I would like to draw your attention to: guessit/plugins/transformers.py has two methods named add_transformer, both of which don't seem to be used. I haven't done anything about it because I wasn't sure if there is some implicit dependency somewhere else.